### PR TITLE
Increase length of the remote_ip column so it can handle IPv6

### DIFF
--- a/install/forms_install.sql
+++ b/install/forms_install.sql
@@ -5,7 +5,7 @@ CREATE TABLE `form_entries` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `form_name` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `url` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `remote_ip` varchar(20) COLLATE utf8_unicode_ci NOT NULL,
+  `remote_ip` varchar(45) COLLATE utf8_unicode_ci NOT NULL,
   `post` text COLLATE utf8_unicode_ci NOT NULL,
   `is_spam` enum('yes','no') COLLATE utf8_unicode_ci NOT NULL DEFAULT 'no',
   `date_added` datetime NOT NULL,


### PR DESCRIPTION
This will resolve an issue when saving form data where the client IP address is IPv6.