### PR TITLE
Fix array to string conversion notices in PHP7 in file 'Fuel_forms'

### DIFF
--- a/libraries/Fuel_forms.php
+++ b/libraries/Fuel_forms.php
@@ -1740,7 +1740,7 @@ class Fuel_form extends Fuel_base_library {
 	 * @access	public
 	 * @param	object	method name
 	 * @param	array	arguments
-	 * @return	array
+	 * @return	mixed
 	 */	
 	public function __call($method, $args)
 	{
@@ -1758,7 +1758,7 @@ class Fuel_form extends Fuel_base_library {
 		{
 			if (property_exists($this, $found[1]))
 			{
-				$method = $this->$found[1];
+				$method = $this->{$found[1]};
 				return $this->$method;
 			}
 		}
@@ -1768,7 +1768,7 @@ class Fuel_form extends Fuel_base_library {
 			{
 				if (!empty($found[1]))
 				{
-					return is_true_val($this->$found[1]);
+					return is_true_val($this->{$found[1]});
 				}
 			}
 		}
@@ -1776,7 +1776,7 @@ class Fuel_form extends Fuel_base_library {
 		{
 			if (property_exists($this, $found[1]))
 			{
-				return !empty($this->$found[1]);
+				return !empty($this->{$found[1]});
 			}
 		}
 		return FALSE;


### PR DESCRIPTION
I'm upgrading a site to PHP 7.1.9 and it is currently displaying a *Notice: Array to String conversion* inside the `Fuel_forms` class. The site worked fine in PHP 5.6.

If you call a variable method by using an array, you need to surround the array with braces.

See this in action at *3v4l.org*: https://3v4l.org/iaGMf

I could verify that the `_has` and `_is` functioned as expected after the fix, but couldn't trigger the `_get` as easily. If you have an easy way to test it, then it should be easy to verify.

Note: the main FUEL module also has quite a few instances that need fixing. I used regex `\$([a-z_]+)->\$([a-z_]+)\[` to find some, just to see if it was indeed affected. The regex does not catch everything, though, obviously.