### PR TITLE
Fix rendered ReCaptcha not using theme defined in form params

### DIFF
--- a/libraries/Forms_custom_fields.php
+++ b/libraries/Forms_custom_fields.php
@@ -52,7 +52,7 @@ class Forms_custom_fields {
 			$params['recaptcha_private_key'] = $this->fuel->forms->config('recaptcha_private_key');
 		}
 
-		$defaults = array('theme' => 'clean', 'error_message' => 'Please enter in a valid captcha value');
+		$defaults = array('recaptcha_theme' => 'clean', 'error_message' => 'Please enter in a valid captcha value');
 		$params = $this->set_defaults($defaults, $params);
 
 		if (isset($_POST["recaptcha_response_field"]))

--- a/libraries/Forms_custom_fields.php
+++ b/libraries/Forms_custom_fields.php
@@ -71,7 +71,7 @@ class Forms_custom_fields {
 
 		$str = '<script>
              var RecaptchaOptions = {
-                theme : \''.$params['theme'].'\'
+                theme : \''.$params['recaptcha_theme'].'\'
              };
         </script>
         ';

--- a/views/_docs/index.php
+++ b/views/_docs/index.php
@@ -169,7 +169,7 @@ $params['validation'] = array('name', 'is_equal_to', 'Please make sure the passw
 $params['slug'] = 'myform'; // used for form action if none is provided to submit to forms/{slug}
 $params['save_entries'] = FALSE; // saves to the form_entries table
 $params['form_action'] = 'http:&#47;&#47;mysite.com/signup'; // if left blank it will be submitted automatically to forms/{slug} to be processed
-$params['anti_spam_method'] = array('method' => 'recaptcha', 'recaptcha_public_key' => 'xxx', 'recaptcha_private_key' => 'xxxxx', 'theme' => 'white');
+$params['anti_spam_method'] = array('method' => 'recaptcha', 'recaptcha_public_key' => 'xxx', 'recaptcha_private_key' => 'xxxxx', 'recaptcha_theme' => 'white');
 $params['submit_button_text'] = 'Submit Form';
 $params['submit_button_value'] = 'Submit'; // used to determine that the form was actually submitted
 $params['reset_button_text'] = 'Reset Form';


### PR DESCRIPTION
When defining a form in the CMS, if `recaptcha` is chosen as the anti-spam method, then its theme can be picked as well.

The theme is stored in a parameter `recaptcha_theme`. However when it comes to rendering, FUEL CMS is looking for a `theme` param. No error is thrown because the `$params` array goes through a method that defaults unset values (and `theme` is defaulted to "clean").

To re-produce:
* Create a form in the CMS, pick `recaptcha` as the anti-spam method, and any theme other than `light`
* Render the form