### PR TITLE
Recaptcha v2 support

### DIFF
--- a/helpers/forms_helper.php
+++ b/helpers/forms_helper.php
@@ -144,11 +144,13 @@ function validate_akismet($api_key, $name, $email, $msg, $log = TRUE)
  */
 function validate_recaptcha($private_key)
 {
-	$resp = recaptcha_check_answer ($private_key,
-									$_SERVER["REMOTE_ADDR"],
-									$_POST["recaptcha_challenge_field"],
-									$_POST["recaptcha_response_field"]);
-	return $resp->is_valid;
+	$CI =& get_instance();
+	$recaptcha = new \ReCaptcha\ReCaptcha($private_key);
+	$resp = $recaptcha->verify(
+		$CI->input->post('g-recaptcha-response'),
+		$_SERVER['REMOTE_ADDR']
+	);
+	return $resp->isSuccess();
 }
 
 

--- a/libraries/Forms_custom_fields.php
+++ b/libraries/Forms_custom_fields.php
@@ -6,15 +6,15 @@ class Forms_custom_fields {
 
 	protected $CI;
 	protected $fuel;
-
+	
 	// --------------------------------------------------------------------
-
+	
 	/**
 	 * Constructor
 	 *
 	 * @access	public
 	 * @return	void
-	 */
+	 */	
 	public function __construct()
 	{
 		$this->CI =& get_instance();
@@ -27,17 +27,17 @@ class Forms_custom_fields {
 	}
 
 	// --------------------------------------------------------------------
-
+	
 	/**
 	 * Creates a reCAPTCHA to combat SPAM as well as the necessary post processing validation rules.
 	 * Additional parameters include "recaptcha_public_key", "recaptcha_private_key" and "<a href="https://developers.google.com/recaptcha/docs/customization" target="_blank">theme</a>":
 	 *
 	 * <a href="https://developers.google.com/recaptcha/" target="_blank">https://developers.google.com/recaptcha/</a>
-	 *
+	 * 
 	 * @access	public
 	 * @param 	array  	An array of parameters to pass to the field type
 	 * @return	string
-	 */
+	 */	
 	public function recaptcha($params = array())
 	{
 		$form_builder =& $params['instance'];
@@ -74,7 +74,7 @@ class Forms_custom_fields {
 
 
 	// --------------------------------------------------------------------
-
+	
 	/**
 	 * Adds Akismet validation to your form as well as the necessary post processing validation rules.
 	 * akismet_api_key
@@ -85,7 +85,7 @@ class Forms_custom_fields {
 	 * @access	public
 	 * @param 	array  	An array of parameters to pass to the field type
 	 * @return	string
-	 */
+	 */	
 	public function akismet($params = array())
 	{
 		$form_builder =& $params['instance'];
@@ -113,24 +113,24 @@ class Forms_custom_fields {
 		return ' ';
 	}
 
-
+	
 	// --------------------------------------------------------------------
-
+	
 	/**
 	 * Creates a honeypot to combat SPAM as well as the necessary post processing validation rules.
 	 * http://www.dexmedia.com/blog/honeypot-technique/
-	 *
+	 * 
 	 * @access	public
 	 * @param 	array  	An array of parameters to pass to the field type
 	 * @return	array
-	 */
+	 */	
 	public function honeypot($params = array())
 	{
 		$form_builder =& $params['instance'];
 
 		$defaults = array('name_field' => '', 'error_message' => 'Invalid submission.');
 		$params = $this->set_defaults($defaults, $params);
-
+		
 		if (!empty($_POST))
 		{
 			$func_str = '$CI =& get_instance();
@@ -146,15 +146,15 @@ class Forms_custom_fields {
 	}
 
 	// --------------------------------------------------------------------
-
+	
 	/**
 	 * Creates an equation to combat SPAM as well as the necessary post processing validation rules.
 	 * http://www.dexmedia.com/blog/honeypot-technique/
-	 *
+	 * 
 	 * @access	public
 	 * @param 	array  	An array of parameters to pass to the field type
 	 * @return	string
-	 */
+	 */	
 	public function equation($params = array())
 	{
 		// check if session is already started and if not, start one
@@ -196,14 +196,14 @@ class Forms_custom_fields {
 	}
 
 	// --------------------------------------------------------------------
-
+	
 	/**
 	 * Adds Stopforumspam validation to your form as well as the necessary post processing validation rules.
 	 *
 	 * @access	public
 	 * @param 	array  	An array of parameters to pass to the field type
 	 * @return	string
-	 */
+	 */	
 	public function stopforumspam($params = array())
 	{
 		$form_builder =& $params['instance'];
@@ -216,7 +216,7 @@ class Forms_custom_fields {
 		{
 			$params['thresholds'] = array_merge($this->fuel->forms->config('stopforumspam'), $params['thresholds']);
 		}
-
+		
 		$defaults = array('name_field' => 'name', 'email_field' => 'email', 'message_field' => '__email_message__', 'error_message' => 'Your message has been flagged as SPAM and cannot be submitted.');
 		$params = $this->set_defaults($defaults, $params);
 
@@ -244,14 +244,14 @@ class Forms_custom_fields {
 	}
 
 	// --------------------------------------------------------------------
-
+	
 	/**
 	 * Creates one of the 4 SPAM fields types. You specify the "method" parameter to determine which one to use.
-	 *
+	 * 
 	 * @access	public
 	 * @param 	array  	An array of parameters to pass to the field type
 	 * @return	string
-	 */
+	 */	
 	public function antispam($params = array())
 	{
 		$form_builder =& $params['instance'];
@@ -271,15 +271,15 @@ class Forms_custom_fields {
 
 
 	// --------------------------------------------------------------------
-
+	
 	/**
 	 * Creates a default set of parameters for the field type.
-	 *
+	 * 
 	 * @access	protected
 	 * @param 	array  	An array of default parameters to pass to the field type
 	 * @param 	array  	An array of parameters to pass to the field type
 	 * @return	array
-	 */
+	 */	
 	protected function set_defaults($defaults, $params = array())
 	{
 

--- a/libraries/Forms_custom_fields.php
+++ b/libraries/Forms_custom_fields.php
@@ -6,15 +6,15 @@ class Forms_custom_fields {
 
 	protected $CI;
 	protected $fuel;
-	
+
 	// --------------------------------------------------------------------
-	
+
 	/**
 	 * Constructor
 	 *
 	 * @access	public
 	 * @return	void
-	 */	
+	 */
 	public function __construct()
 	{
 		$this->CI =& get_instance();
@@ -27,17 +27,17 @@ class Forms_custom_fields {
 	}
 
 	// --------------------------------------------------------------------
-	
+
 	/**
 	 * Creates a reCAPTCHA to combat SPAM as well as the necessary post processing validation rules.
 	 * Additional parameters include "recaptcha_public_key", "recaptcha_private_key" and "<a href="https://developers.google.com/recaptcha/docs/customization" target="_blank">theme</a>":
 	 *
 	 * <a href="https://developers.google.com/recaptcha/" target="_blank">https://developers.google.com/recaptcha/</a>
-	 * 
+	 *
 	 * @access	public
 	 * @param 	array  	An array of parameters to pass to the field type
 	 * @return	string
-	 */	
+	 */
 	public function recaptcha($params = array())
 	{
 		$form_builder =& $params['instance'];
@@ -52,36 +52,29 @@ class Forms_custom_fields {
 			$params['recaptcha_private_key'] = $this->fuel->forms->config('recaptcha_private_key');
 		}
 
-		$defaults = array('recaptcha_theme' => 'clean', 'error_message' => 'Please enter in a valid captcha value');
+		$defaults = array('recaptcha_theme' => 'light', 'error_message' => 'Please enter in a valid captcha value');
 		$params = $this->set_defaults($defaults, $params);
 
-		if (isset($_POST["recaptcha_response_field"]))
+		if (isset($_POST["g-recaptcha-response"]))
 		{
-			$_POST[$params['key']] = $_POST["recaptcha_response_field"];
+			$_POST[$params['key']] = $_POST["g-recaptcha-response"];
 		}
 
         $params['type'] = 'none';
         $func_str = '$CI =& get_instance();
         	$validator =& $CI->form_builder->get_validator();
-        	$validator->add_rule("recaptcha_response_field", "required", "'.$params['error_message'].'", array("'.$this->CI->input->post('recaptcha_response_field').'"));
+        	$validator->add_rule("recaptcha_response_field", "required", "'.$params['error_message'].'", array("'.$this->CI->input->post('g-recaptcha-response').'"));
 			$validator->add_rule("recaptcha_response_field", "validate_recaptcha", "'.$params['error_message'].'", array("'.$params['recaptcha_private_key'].'"));
 			';
 		$func = create_function('$value', $func_str);
 		$form_builder->set_post_process($params['key'], $func);
 
-		$str = '<script>
-             var RecaptchaOptions = {
-                theme : \''.$params['recaptcha_theme'].'\'
-             };
-        </script>
-        ';
-		$str .= recaptcha_get_html($params['recaptcha_public_key']);
-		return $str;
+		return recaptcha_get_html($params['recaptcha_public_key'], $params['recaptcha_theme']);
 	}
 
 
 	// --------------------------------------------------------------------
-	
+
 	/**
 	 * Adds Akismet validation to your form as well as the necessary post processing validation rules.
 	 * akismet_api_key
@@ -92,7 +85,7 @@ class Forms_custom_fields {
 	 * @access	public
 	 * @param 	array  	An array of parameters to pass to the field type
 	 * @return	string
-	 */	
+	 */
 	public function akismet($params = array())
 	{
 		$form_builder =& $params['instance'];
@@ -120,24 +113,24 @@ class Forms_custom_fields {
 		return ' ';
 	}
 
-	
+
 	// --------------------------------------------------------------------
-	
+
 	/**
 	 * Creates a honeypot to combat SPAM as well as the necessary post processing validation rules.
 	 * http://www.dexmedia.com/blog/honeypot-technique/
-	 * 
+	 *
 	 * @access	public
 	 * @param 	array  	An array of parameters to pass to the field type
 	 * @return	array
-	 */	
+	 */
 	public function honeypot($params = array())
 	{
 		$form_builder =& $params['instance'];
 
 		$defaults = array('name_field' => '', 'error_message' => 'Invalid submission.');
 		$params = $this->set_defaults($defaults, $params);
-		
+
 		if (!empty($_POST))
 		{
 			$func_str = '$CI =& get_instance();
@@ -153,15 +146,15 @@ class Forms_custom_fields {
 	}
 
 	// --------------------------------------------------------------------
-	
+
 	/**
 	 * Creates an equation to combat SPAM as well as the necessary post processing validation rules.
 	 * http://www.dexmedia.com/blog/honeypot-technique/
-	 * 
+	 *
 	 * @access	public
 	 * @param 	array  	An array of parameters to pass to the field type
 	 * @return	string
-	 */	
+	 */
 	public function equation($params = array())
 	{
 		// check if session is already started and if not, start one
@@ -203,14 +196,14 @@ class Forms_custom_fields {
 	}
 
 	// --------------------------------------------------------------------
-	
+
 	/**
 	 * Adds Stopforumspam validation to your form as well as the necessary post processing validation rules.
 	 *
 	 * @access	public
 	 * @param 	array  	An array of parameters to pass to the field type
 	 * @return	string
-	 */	
+	 */
 	public function stopforumspam($params = array())
 	{
 		$form_builder =& $params['instance'];
@@ -223,7 +216,7 @@ class Forms_custom_fields {
 		{
 			$params['thresholds'] = array_merge($this->fuel->forms->config('stopforumspam'), $params['thresholds']);
 		}
-		
+
 		$defaults = array('name_field' => 'name', 'email_field' => 'email', 'message_field' => '__email_message__', 'error_message' => 'Your message has been flagged as SPAM and cannot be submitted.');
 		$params = $this->set_defaults($defaults, $params);
 
@@ -251,14 +244,14 @@ class Forms_custom_fields {
 	}
 
 	// --------------------------------------------------------------------
-	
+
 	/**
 	 * Creates one of the 4 SPAM fields types. You specify the "method" parameter to determine which one to use.
-	 * 
+	 *
 	 * @access	public
 	 * @param 	array  	An array of parameters to pass to the field type
 	 * @return	string
-	 */	
+	 */
 	public function antispam($params = array())
 	{
 		$form_builder =& $params['instance'];
@@ -278,15 +271,15 @@ class Forms_custom_fields {
 
 
 	// --------------------------------------------------------------------
-	
+
 	/**
 	 * Creates a default set of parameters for the field type.
-	 * 
+	 *
 	 * @access	protected
 	 * @param 	array  	An array of default parameters to pass to the field type
 	 * @param 	array  	An array of parameters to pass to the field type
 	 * @return	array
-	 */	
+	 */
 	protected function set_defaults($defaults, $params = array())
 	{
 

--- a/libraries/Fuel_forms.php
+++ b/libraries/Fuel_forms.php
@@ -751,7 +751,7 @@ class Fuel_form extends Fuel_base_library {
 					// pre save hook
 					$this->call_hook('pre_save');
 
-					$model =& $this->CI->fuel->forms->model('form_entries');
+					$model = $this->CI->fuel->forms->model('form_entries');
 					$entry = $model->create();
 					$entry->url = last_url();
 					$entry->post = json_encode($posted);

--- a/libraries/layouts/Antispam_field_layout.php
+++ b/libraries/layouts/Antispam_field_layout.php
@@ -44,7 +44,7 @@ class Antispam_field_layout extends Base_field_layout {
 		$fields['akismet_api_key'] = array('class' => 'akismet_api_key', 'label' => 'Akismet API key');
 		$fields['recaptcha_public_key'] = array('class' => 'recaptcha_public_key', 'label' => 'reCAPTCHA public key', 'size' => 60);
 		$fields['recaptcha_private_key'] = array('class' => 'recaptcha_private_key', 'label' => 'reCAPTCHA private key', 'size' => 60);
-		$fields['recaptcha_theme'] = array('type' => 'select',  'label' => 'reCAPTCHA theme', 'options' => array('clean' => 'clean', 'blackglass' => 'blackglass', 'white' => 'white', 'red' => 'red'), 'class' => 'recaptcha_theme');
+		$fields['recaptcha_theme'] = array('type' => 'select',  'label' => 'reCAPTCHA theme', 'options' => array('light' => 'light', 'dark' => 'dark'), 'class' => 'recaptcha_theme');
 		$fields = $this->process_fields($fields);
 		return $fields;
 	}

--- a/libraries/third_party/recaptchalib.php
+++ b/libraries/third_party/recaptchalib.php
@@ -1,277 +1,32 @@
 <?php
-/*
- * This is a PHP library that handles calling reCAPTCHA.
- *    - Documentation and latest version
- *          http://recaptcha.net/plugins/php/
- *    - Get a reCAPTCHA API Key
- *          https://www.google.com/recaptcha/admin/create
- *    - Discussion group
- *          http://groups.google.com/group/recaptcha
- *
- * Copyright (c) 2007 reCAPTCHA -- http://recaptcha.net
- * AUTHORS:
- *   Mike Crawford
- *   Ben Maurer
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
 
 /**
- * The reCAPTCHA server URL's
+ * The reCAPTCHA server URLs
  */
-define("RECAPTCHA_API_SERVER", "http://www.google.com/recaptcha/api");
-define("RECAPTCHA_API_SECURE_SERVER", "https://www.google.com/recaptcha/api");
-define("RECAPTCHA_VERIFY_SERVER", "www.google.com");
-
-/**
- * Encodes the given data into a query string format
- * @param $data - array of string elements to be encoded
- * @return string - encoded request
- */
-function _recaptcha_qsencode ($data) {
-        $req = "";
-        foreach ( $data as $key => $value )
-                $req .= $key . '=' . urlencode( stripslashes($value) ) . '&';
-
-        // Cut the last '&'
-        $req=substr($req,0,strlen($req)-1);
-        return $req;
-}
-
-
-
-/**
- * Submits an HTTP POST to a reCAPTCHA server
- * @param string $host
- * @param string $path
- * @param array $data
- * @param int port
- * @return array response
- */
-function _recaptcha_http_post($host, $path, $data, $port = 80) {
-
-        $req = _recaptcha_qsencode ($data);
-
-        $http_request  = "POST $path HTTP/1.0\r\n";
-        $http_request .= "Host: $host\r\n";
-        $http_request .= "Content-Type: application/x-www-form-urlencoded;\r\n";
-        $http_request .= "Content-Length: " . strlen($req) . "\r\n";
-        $http_request .= "User-Agent: reCAPTCHA/PHP\r\n";
-        $http_request .= "\r\n";
-        $http_request .= $req;
-
-        $response = '';
-        if( false == ( $fs = @fsockopen($host, $port, $errno, $errstr, 10) ) ) {
-                die ('Could not open socket');
-        }
-
-        fwrite($fs, $http_request);
-
-        while ( !feof($fs) )
-                $response .= fgets($fs, 1160); // One TCP-IP packet
-        fclose($fs);
-        $response = explode("\r\n\r\n", $response, 2);
-
-        return $response;
-}
-
-
+define("RECAPTCHA_API_SERVER", "https://www.google.com/recaptcha/api");
 
 /**
  * Gets the challenge HTML (javascript and non-javascript version).
  * This is called from the browser, and the resulting reCAPTCHA HTML widget
  * is embedded within the HTML form it was called from.
- * @param string $pubkey A public key for reCAPTCHA
- * @param string $error The error given by reCAPTCHA (optional, default is null)
- * @param boolean $use_ssl Should the request be made over ssl? (optional, default is false)
-
+ * @param string $public_key A public key for reCAPTCHA
+ * @param string $theme Used to style the reCAPTCHA, can be 'light' or 'dark'
  * @return string - The HTML to be embedded in the user's form.
  */
-function recaptcha_get_html ($pubkey, $error = null, $use_ssl = false)
+function recaptcha_get_html($public_key, $theme = 'light')
 {
-	if ($pubkey == null || $pubkey == '') {
-		die ("To use reCAPTCHA you must get an API key from <a href='https://www.google.com/recaptcha/admin/create'>https://www.google.com/recaptcha/admin/create</a>");
-	}
-	
-	if ($use_ssl) {
-                $server = RECAPTCHA_API_SECURE_SERVER;
-        } else {
-                $server = RECAPTCHA_API_SERVER;
-        }
+	$recaptcha_script_url = RECAPTCHA_API_SERVER . '.js';
+	$recaptcha_fallback_url = RECAPTCHA_API_SERVER . '/fallback?k=' . $public_key;
 
-        $errorpart = "";
-        if ($error) {
-           $errorpart = "&amp;error=" . $error;
-        }
-        return '<script type="text/javascript" src="'. $server . '/challenge?k=' . $pubkey . $errorpart . '"></script>
-
-	<noscript>
-  		<iframe src="'. $server . '/noscript?k=' . $pubkey . $errorpart . '" height="300" width="500" frameborder="0"></iframe><br/>
-  		<textarea name="recaptcha_challenge_field" rows="3" cols="40"></textarea>
-  		<input type="hidden" name="recaptcha_response_field" value="manual_challenge"/>
-	</noscript>';
+	return fuel_block(array(
+		'module' => FORMS_FOLDER,
+		'view' => 'recaptcha_view',
+		'only_views' => TRUE,
+		'vars' => array(
+			'recaptcha_script_url' => $recaptcha_script_url,
+			'recaptcha_fallback_url' => $recaptcha_fallback_url,
+			'recaptcha_public_key' => $public_key,
+			'recaptcha_theme' => $theme,
+		)
+	));
 }
-
-
-
-
-/**
- * A ReCaptchaResponse is returned from recaptcha_check_answer()
- */
-class ReCaptchaResponse {
-        var $is_valid;
-        var $error;
-}
-
-
-/**
-  * Calls an HTTP POST function to verify if the user's guess was correct
-  * @param string $privkey
-  * @param string $remoteip
-  * @param string $challenge
-  * @param string $response
-  * @param array $extra_params an array of extra variables to post to the server
-  * @return ReCaptchaResponse
-  */
-function recaptcha_check_answer ($privkey, $remoteip, $challenge, $response, $extra_params = array())
-{
-	if ($privkey == null || $privkey == '') {
-		die ("To use reCAPTCHA you must get an API key from <a href='https://www.google.com/recaptcha/admin/create'>https://www.google.com/recaptcha/admin/create</a>");
-	}
-
-	if ($remoteip == null || $remoteip == '') {
-		die ("For security reasons, you must pass the remote ip to reCAPTCHA");
-	}
-
-	
-	
-        //discard spam submissions
-        if ($challenge == null || strlen($challenge) == 0 || $response == null || strlen($response) == 0) {
-                $recaptcha_response = new ReCaptchaResponse();
-                $recaptcha_response->is_valid = false;
-                $recaptcha_response->error = 'incorrect-captcha-sol';
-                return $recaptcha_response;
-        }
-
-        $response = _recaptcha_http_post (RECAPTCHA_VERIFY_SERVER, "/recaptcha/api/verify",
-                                          array (
-                                                 'privatekey' => $privkey,
-                                                 'remoteip' => $remoteip,
-                                                 'challenge' => $challenge,
-                                                 'response' => $response
-                                                 ) + $extra_params
-                                          );
-
-        $answers = explode ("\n", $response [1]);
-        $recaptcha_response = new ReCaptchaResponse();
-
-        if (trim ($answers [0]) == 'true') {
-                $recaptcha_response->is_valid = true;
-        }
-        else {
-                $recaptcha_response->is_valid = false;
-                $recaptcha_response->error = $answers [1];
-        }
-        return $recaptcha_response;
-
-}
-
-/**
- * gets a URL where the user can sign up for reCAPTCHA. If your application
- * has a configuration page where you enter a key, you should provide a link
- * using this function.
- * @param string $domain The domain where the page is hosted
- * @param string $appname The name of your application
- */
-function recaptcha_get_signup_url ($domain = null, $appname = null) {
-	return "https://www.google.com/recaptcha/admin/create?" .  _recaptcha_qsencode (array ('domains' => $domain, 'app' => $appname));
-}
-
-function _recaptcha_aes_pad($val) {
-	$block_size = 16;
-	$numpad = $block_size - (strlen ($val) % $block_size);
-	return str_pad($val, strlen ($val) + $numpad, chr($numpad));
-}
-
-/* Mailhide related code */
-
-function _recaptcha_aes_encrypt($val,$ky) {
-	if (! function_exists ("mcrypt_encrypt")) {
-		die ("To use reCAPTCHA Mailhide, you need to have the mcrypt php module installed.");
-	}
-	$mode=MCRYPT_MODE_CBC;   
-	$enc=MCRYPT_RIJNDAEL_128;
-	$val=_recaptcha_aes_pad($val);
-	return mcrypt_encrypt($enc, $ky, $val, $mode, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
-}
-
-
-function _recaptcha_mailhide_urlbase64 ($x) {
-	return strtr(base64_encode ($x), '+/', '-_');
-}
-
-/* gets the reCAPTCHA Mailhide url for a given email, public key and private key */
-function recaptcha_mailhide_url($pubkey, $privkey, $email) {
-	if ($pubkey == '' || $pubkey == null || $privkey == "" || $privkey == null) {
-		die ("To use reCAPTCHA Mailhide, you have to sign up for a public and private key, " .
-		     "you can do so at <a href='http://www.google.com/recaptcha/mailhide/apikey'>http://www.google.com/recaptcha/mailhide/apikey</a>");
-	}
-	
-
-	$ky = pack('H*', $privkey);
-	$cryptmail = _recaptcha_aes_encrypt ($email, $ky);
-	
-	return "http://www.google.com/recaptcha/mailhide/d?k=" . $pubkey . "&c=" . _recaptcha_mailhide_urlbase64 ($cryptmail);
-}
-
-/**
- * gets the parts of the email to expose to the user.
- * eg, given johndoe@example,com return ["john", "example.com"].
- * the email is then displayed as john...@example.com
- */
-function _recaptcha_mailhide_email_parts ($email) {
-	$arr = preg_split("/@/", $email );
-
-	if (strlen ($arr[0]) <= 4) {
-		$arr[0] = substr ($arr[0], 0, 1);
-	} else if (strlen ($arr[0]) <= 6) {
-		$arr[0] = substr ($arr[0], 0, 3);
-	} else {
-		$arr[0] = substr ($arr[0], 0, 4);
-	}
-	return $arr;
-}
-
-/**
- * Gets html to display an email address given a public an private key.
- * to get a key, go to:
- *
- * http://www.google.com/recaptcha/mailhide/apikey
- */
-function recaptcha_mailhide_html($pubkey, $privkey, $email) {
-	$emailparts = _recaptcha_mailhide_email_parts ($email);
-	$url = recaptcha_mailhide_url ($pubkey, $privkey, $email);
-	
-	return htmlentities($emailparts[0]) . "<a href='" . htmlentities ($url) .
-		"' onclick=\"window.open('" . htmlentities ($url) . "', '', 'toolbar=0,scrollbars=0,location=0,statusbar=0,menubar=0,resizable=0,width=500,height=300'); return false;\" title=\"Reveal this e-mail address\">...</a>@" . htmlentities ($emailparts [1]);
-
-}
-
-
-?>

--- a/views/_blocks/recaptcha_view.php
+++ b/views/_blocks/recaptcha_view.php
@@ -1,0 +1,27 @@
+<script src="<?php echo $recaptcha_script_url; ?>" async defer></script>
+<div
+		class="g-recaptcha"
+		data-sitekey="<?php echo $recaptcha_public_key; ?>"
+		data-theme="<?php echo $recaptcha_theme; ?>">
+</div>
+<noscript>
+	<div>
+		<div style="width: 302px; height: 422px; position: relative;">
+			<div style="width: 302px; height: 422px; position: absolute;">
+				<iframe src="<?php echo $recaptcha_fallback_url; ?>"
+						frameborder="0" scrolling="no"
+						style="width: 302px; height:422px; border-style: none;">
+				</iframe>
+			</div>
+		</div>
+		<div style="width: 300px; height: 60px; border-style: none;
+					   bottom: 12px; left: 25px; margin: 0px; padding: 0px; right: 25px;
+					   background: #f9f9f9; border: 1px solid #c1c1c1; border-radius: 3px;">
+		  <textarea id="g-recaptcha-response" name="g-recaptcha-response"
+					class="g-recaptcha-response"
+					style="width: 250px; height: 40px; border: 1px solid #c1c1c1;
+							  margin: 10px 25px; padding: 0px; resize: none;">
+		  </textarea>
+		</div>
+	</div>
+</noscript>


### PR DESCRIPTION
- Enables ReCaptcha2 support.
- Removes ReCaptcha1 support!
- Fixes an "Only variables should be assigned by reference" error in Fuel_forms.

Breaking changes:
- `recaptcha_public_key` and `recaptcha_private_key` are now ReCaptcha 2's *site* and *secret* keys, respectively, and need to be updated by users either in the forms/config.php file or in the database entries themselves. **The validator will now reject ReCaptcha1 configuration!**