### PR TITLE
Fix invalid parameter names in Date_field_layout and Phone_field_layout.

### DIFF
--- a/libraries/layouts/Date_field_layout.php
+++ b/libraries/layouts/Date_field_layout.php
@@ -15,7 +15,7 @@ class Date_field_layout extends Base_field_layout {
 	 * @param	mixed 	The value to validate
 	 * @return	object
 	 */	
-	function frontend_validation($value)
+	function frontend_validation($name)
 	{
 		$validator = $this->get_validator();
 		$validator->add_rule($name, 'valid_date', 'Please enter in a valid date');

--- a/libraries/layouts/Phone_field_layout.php
+++ b/libraries/layouts/Phone_field_layout.php
@@ -15,7 +15,7 @@ class Phone_field_layout extends Base_field_layout {
 	 * @param	mixed 	The value to validate
 	 * @return	object
 	 */	
-	function frontend_validation($value)
+	function frontend_validation($name)
 	{
 		$validator = $this->get_validator();
 		$validator->add_rule($name, 'valid_phone', 'Please enter in a valid phone number');


### PR DESCRIPTION
The two functions call validator::add_rule with a different argument,
meaning an error will be thrown as soon as the code is executed. This
commit makes the two functions behave like Email_field_layout's function.